### PR TITLE
Fixed French translation (WebFilechooser "open")

### DIFF
--- a/src/com/alee/laf/resources/language.xml
+++ b/src/com/alee/laf/resources/language.xml
@@ -606,7 +606,7 @@
             <value lang="pl">Otwarte</value>
             <value lang="ar">فتح</value>
             <value lang="es">Abierto</value>
-            <value lang="fr">Ouvert</value>
+            <value lang="fr">Ouvrir</value>
             <value lang="pt">Abrir</value>
             <value lang="de">Öffnen</value>
         </record>


### PR DESCRIPTION
Wrong translation in French of "open" for WebFilechooser ("Ouvert" instead of "Ouvrir").
