### PR TITLE
Fix for null actualTransitionEffect in ImageTransition.performTransition

### DIFF
--- a/src/com/alee/extended/transition/ImageTransition.java
+++ b/src/com/alee/extended/transition/ImageTransition.java
@@ -216,8 +216,10 @@ public class ImageTransition extends JComponent implements ActionListener
             actualTransitionEffect = transitionEffects.get ( MathUtils.random ( transitionEffects.size () ) );
         }
 
+        long animationDelay = actualTransitionEffect != null ? actualTransitionEffect.getAnimationDelay () : 0;
+
         // Starting new transition
-        animator = new WebTimer ( "ImageTransition.animator", actualTransitionEffect.getAnimationDelay (), this );
+        animator = new WebTimer ( "ImageTransition.animator", animationDelay, this );
 
         // Starting transition
         fireTransitionStarted ();


### PR DESCRIPTION
Avoid an java.lang.NullPointerException in case an effect is not provided.

Note that ImageTransition.actionPerformed ends the transition if actualTransitionEffect is null.
