### PR TITLE
Adding property to honor non-UIResource borders installed on components

### DIFF
--- a/src/com/alee/laf/WebLookAndFeel.java
+++ b/src/com/alee/laf/WebLookAndFeel.java
@@ -83,6 +83,21 @@ import java.util.List;
 
 public class WebLookAndFeel extends BasicLookAndFeel
 {
+   
+   /**
+    * If this client property is set to {@link Boolean#TRUE} on a component,
+    * UI delegates should follow the typical Swing behavior of not overriding
+    * a user-defined border on it.
+    */
+   public static final String PROPERTY_HONOR_USER_BORDER = "WebLookAndFeel.honorUserBorder";
+   
+   /**
+    * If this system property is set to <code>true</code>,  UI delegates should
+    * follow the typical Swing behavior of not overriding a user-defined border
+    * if one is installed on components.
+    */
+   public static final String PROPERTY_HONOR_USER_BORDERS = "WebLookAndFeel.honorUserBorders";
+   
     /**
      * Some known UI constants.
      */
@@ -408,6 +423,31 @@ public class WebLookAndFeel extends BasicLookAndFeel
         // Option pane
         table.put ( "OptionPaneUI", optionPaneUI );
     }
+    
+    /**
+     * Adds some default colors to the <code>UIDefaults</code> that are not
+     * used by WebLookAndFeel directly, but will help custom components that
+     * assume BasicLookAndFeel conventions.
+     */
+    @Override
+    protected void initSystemColorDefaults( UIDefaults table )
+    {
+        super.initSystemColorDefaults( table );
+        
+        String textColor = "#"+ColorUtils.getHexColor( StyleConstants.textColor );
+        
+        String[] defaultSystemColors =
+        {
+            "menu", "#ffffff",
+            "menuText", textColor,
+            "textHighlight", "#" + ColorUtils.getHexColor( StyleConstants.textSelectionColor ),
+            "textHighlightText", textColor,
+            "textInactiveText", "#" + ColorUtils.getHexColor( StyleConstants.disabledTextColor ),
+            "controlText", textColor,
+        };
+
+        loadSystemColors( table, defaultSystemColors, isNativeLookAndFeel() );
+    }
 
     /**
      * Initializes WebLookAndFeel defaults (like default renderers, component borders and such).
@@ -425,7 +465,21 @@ public class WebLookAndFeel extends BasicLookAndFeel
 
         // Fonts
         initializeFonts ( table );
-
+        
+        // JTextFields
+        Object textComponentBorder =
+                new SwingLazyValue ( "javax.swing.plaf.BorderUIResource.LineBorderUIResource", new Object[] { StyleConstants.shadeColor });
+        table.put( "TextField.border", textComponentBorder );
+        
+        // JTextAreas
+        table.put( "TextArea.border", textComponentBorder );
+        
+        // JEditorPanes
+        table.put( "EditorPane.border", textComponentBorder );
+        
+        // JTextPanes
+        table.put( "TextPane.border", textComponentBorder );
+        
         // Option pane
         table.put ( "OptionPane.messageAreaBorder",
                 new SwingLazyValue ( "javax.swing.plaf.BorderUIResource$EmptyBorderUIResource", new Object[]{ 0, 0, 5, 0 } ) );
@@ -436,7 +490,7 @@ public class WebLookAndFeel extends BasicLookAndFeel
 
         // Scroll bars minimum size
         table.put ( "ScrollBar.minimumThumbSize", new Dimension ( WebScrollBarStyle.minThumbWidth, WebScrollBarStyle.minThumbHeight ) );
-
+        
         // Tree icons
         table.put ( "Tree.openIcon", WebTreeUI.OPEN_ICON );
         table.put ( "Tree.closedIcon", WebTreeUI.CLOSED_ICON );

--- a/src/com/alee/laf/checkbox/WebCheckBoxUI.java
+++ b/src/com/alee/laf/checkbox/WebCheckBoxUI.java
@@ -29,6 +29,8 @@ import com.alee.utils.laf.ShapeProvider;
 import com.alee.utils.swing.WebTimer;
 
 import javax.swing.*;
+import javax.swing.border.Border;
+import javax.swing.plaf.BorderUIResource;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicCheckBoxUI;
 import javax.swing.tree.TreeCellRenderer;
@@ -386,6 +388,15 @@ public class WebCheckBoxUI extends BasicCheckBoxUI implements ShapeProvider
      */
     protected void updateBorder ()
     {
+        if ( SwingUtils.getHonorUserBorders(checkBox) )
+        {
+            Border oldBorder = checkBox.getBorder();
+            if (!(oldBorder instanceof BorderUIResource))
+            {
+                return;
+            }
+        }
+        
         // Actual margin
         final boolean ltr = checkBox.getComponentOrientation ().isLeftToRight ();
         final Insets m = new Insets ( margin.top, ltr ? margin.left : margin.right, margin.bottom, ltr ? margin.right : margin.left );

--- a/src/com/alee/laf/label/WebLabelUI.java
+++ b/src/com/alee/laf/label/WebLabelUI.java
@@ -26,6 +26,8 @@ import com.alee.utils.SwingUtils;
 import com.alee.utils.swing.BorderMethods;
 
 import javax.swing.*;
+import javax.swing.border.Border;
+import javax.swing.plaf.BorderUIResource;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicLabelUI;
 import java.awt.*;
@@ -132,6 +134,15 @@ public class WebLabelUI extends BasicLabelUI implements BorderMethods
     {
         if ( label != null )
         {
+            if ( SwingUtils.getHonorUserBorders(label) )
+            {
+                Border oldBorder = label.getBorder();
+                if (!(oldBorder instanceof BorderUIResource))
+                {
+                    return;
+                }
+            }
+            
             // Actual margin
             final boolean ltr = label.getComponentOrientation ().isLeftToRight ();
             final Insets m = new Insets ( margin.top, ltr ? margin.left : margin.right, margin.bottom, ltr ? margin.right : margin.left );

--- a/src/com/alee/laf/panel/WebPanelUI.java
+++ b/src/com/alee/laf/panel/WebPanelUI.java
@@ -30,6 +30,8 @@ import com.alee.utils.laf.ShapeProvider;
 import com.alee.utils.swing.BorderMethods;
 
 import javax.swing.*;
+import javax.swing.border.Border;
+import javax.swing.plaf.BorderUIResource;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicPanelUI;
 import java.awt.*;
@@ -186,8 +188,17 @@ public class WebPanelUI extends BasicPanelUI implements ShapeProvider, BorderMet
     @Override
     public void updateBorder ()
     {
-        if ( panel != null )
+    	if ( panel != null )
         {
+            if ( SwingUtils.getHonorUserBorders(panel) )
+            {
+                Border oldBorder = panel.getBorder();
+                if (!(oldBorder instanceof BorderUIResource))
+                {
+                    return;
+                }
+            }
+            
             // Actual margin
             final boolean ltr = panel.getComponentOrientation ().isLeftToRight ();
             final Insets m = new Insets ( margin.top, ltr ? margin.left : margin.right, margin.bottom, ltr ? margin.right : margin.left );

--- a/src/com/alee/laf/rootpane/WebRootPaneLayout.java
+++ b/src/com/alee/laf/rootpane/WebRootPaneLayout.java
@@ -150,7 +150,7 @@ public class WebRootPaneLayout extends AbstractLayoutManager
         // Placing window resize corner
         if ( showResizeCorner )
         {
-            parent.setComponentZOrder ( resizeCorner, 0 );
+            //parent.setComponentZOrder ( resizeCorner, 0 );
             final Dimension ps = resizeCorner.getPreferredSize ();
             resizeCorner.setVisible ( true );
             resizeCorner.setBounds ( s.width - i.right - ps.width - 2, s.height - i.bottom - ps.height - 2, ps.width, ps.height );

--- a/src/com/alee/laf/table/WebTable.java
+++ b/src/com/alee/laf/table/WebTable.java
@@ -22,7 +22,6 @@ import com.alee.utils.GeometryUtils;
 import com.alee.utils.ReflectUtils;
 import com.alee.utils.SwingUtils;
 import com.alee.utils.swing.FontMethods;
-import com.alee.utils.swing.WebDefaultCellEditor;
 
 import javax.swing.*;
 import javax.swing.plaf.UIResource;
@@ -30,7 +29,6 @@ import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 import java.awt.*;
-import java.lang.reflect.InvocationTargetException;
 import java.util.EventObject;
 import java.util.Vector;
 

--- a/src/com/alee/utils/SwingUtils.java
+++ b/src/com/alee/utils/SwingUtils.java
@@ -23,6 +23,7 @@ import com.alee.extended.filechooser.WebFileChooserField;
 import com.alee.extended.filechooser.WebPathField;
 import com.alee.extended.panel.WebCollapsiblePane;
 import com.alee.laf.StyleConstants;
+import com.alee.laf.WebLookAndFeel;
 import com.alee.laf.rootpane.WebRootPaneUI;
 import com.alee.managers.hotkey.HotkeyData;
 import com.alee.managers.hotkey.HotkeyRunnable;
@@ -107,6 +108,21 @@ public final class SwingUtils
      */
     private static Set<SoftReference<BearingCacheEntry>> softBearingCache = new HashSet<SoftReference<BearingCacheEntry>> ();
 
+    /**
+     * Returns whether UI delegates should honor a user-specified border on this
+     * component.
+     */
+    public static boolean getHonorUserBorders(JComponent component)
+    {
+        if (Boolean.getBoolean(WebLookAndFeel.PROPERTY_HONOR_USER_BORDERS))
+        {
+            return true;
+        }
+        Object prop = component
+                .getClientProperty(WebLookAndFeel.PROPERTY_HONOR_USER_BORDER);
+        return Boolean.TRUE.equals(prop);
+    }
+    
     /**
      * Returns whether window in which specified component located is decorated by L&amp;F or not.
      *


### PR DESCRIPTION
This patche addresses two issues:
1. Adds some extra defaults to UIDefaults so custom components based off of BasicLookAndFeel paradigms can better blend in with WebLookAndFeel.
2. Adds properties to allow an application, or individual components, to keep their borders if a non-UIResource border is installed.  This behavior is more inline with Swing standards, but the patch keeps this behavior disabled by default, so out-of-the-box, things in WebLaF behave like they always have.  This allows applications supporting pluggable LaFs to use e.g. EmptyBorders to space things in certain parts of their application.
