### PR TITLE
Fire an event when setting LineColorChooser color

### DIFF
--- a/src/com/alee/laf/colorchooser/LineColorChooser.java
+++ b/src/com/alee/laf/colorchooser/LineColorChooser.java
@@ -155,7 +155,7 @@ public class LineColorChooser extends WebPanel
     {
         // Retrieving hue from Color
         setHue ( 360 - Math.round ( ( float ) 360 * Color.RGBtoHSB ( color.getRed (), color.getGreen (), color.getBlue (), null )[ 0 ] ),
-                false );
+                true );
     }
 
     public Color getColor ()


### PR DESCRIPTION
WebColorChooserPanel palette's "side color", for example, depends on a LineColorChooser change listener in order to be updated.