### PR TITLE
Added DaemonThreadFactory. fixes #172

### DIFF
--- a/modules/core/src/com/alee/utils/concurrent/DaemonThreadFactory.java
+++ b/modules/core/src/com/alee/utils/concurrent/DaemonThreadFactory.java
@@ -1,0 +1,25 @@
+package com.alee.utils.concurrent;
+
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * A thread factory that only produces
+ * daemon threads.
+ * @author Adolph C.
+ */
+public class DaemonThreadFactory implements ThreadFactory
+{
+	/**
+	 * Constructs a new daemon thread.
+	 *
+	 * @param r a runnable to be executed by new thread instance
+	 * @return constructed thread.
+	 */
+	@Override
+	public Thread newThread(Runnable r)
+	{
+		Thread dThread = new Thread(r);
+		dThread.setDaemon(true);
+		return dThread;
+	}
+}

--- a/modules/ui/src/com/alee/extended/list/WebFileListCellRenderer.java
+++ b/modules/ui/src/com/alee/extended/list/WebFileListCellRenderer.java
@@ -24,6 +24,7 @@ import com.alee.laf.label.WebLabel;
 import com.alee.laf.list.WebListCellRenderer;
 import com.alee.utils.FileUtils;
 import com.alee.utils.ImageUtils;
+import com.alee.utils.concurrent.DaemonThreadFactory;
 import com.alee.utils.file.FileDescription;
 
 import javax.swing.*;
@@ -103,7 +104,7 @@ public class WebFileListCellRenderer extends WebListCellRenderer
     /**
      * Executor service for thumbnails generation.
      */
-    protected ExecutorService executorService = Executors.newSingleThreadExecutor ();
+    protected ExecutorService executorService = Executors.newSingleThreadExecutor ( new DaemonThreadFactory() );
 
     /**
      * Constructs cell renderer for the specified file list.


### PR DESCRIPTION
Added a DaemonThreadFactory that can be used to have executors shutdown
when the application has been closed. The factory was added to the
WebFileListCellRenderer's ExecutorService.
