### PR TITLE
Fix for NullPointerException in DocumentDragHandler

### DIFF
--- a/modules/ui/src/com/alee/extended/tab/DocumentDragHandler.java
+++ b/modules/ui/src/com/alee/extended/tab/DocumentDragHandler.java
@@ -310,6 +310,7 @@ public class DocumentDragHandler extends TransferHandler
                 if ( readyToDrag )
                 {
                     tabbedPane.getTransferHandler ().exportAsDrag ( tabbedPane, e, TransferHandler.MOVE );
+                    readyToDrag = false;
                 }
             }
 


### PR DESCRIPTION
Disabled dragging in DocumentDragHandler as soon as one drag operation started so that multiple drags would not get started.
