### PR TITLE
Fixed default scroll speed for all WebScrollPane instances (issue #162)

### DIFF
--- a/modules/ui/src/com/alee/laf/scroll/WebScrollPane.java
+++ b/modules/ui/src/com/alee/laf/scroll/WebScrollPane.java
@@ -51,7 +51,9 @@ public class WebScrollPane extends JScrollPane implements ShapeProvider, SizeMet
         super ( view );
         setDrawBorder ( drawBorder );
         getWebHorizontalScrollBar ().setPaintTrack ( drawInnerBorder );
+        getWebHorizontalScrollBar ().setUnitIncrement ( 16 );
         getWebVerticalScrollBar ().setPaintTrack ( drawInnerBorder );
+        getWebVerticalScrollBar ().setUnitIncrement ( 16 );
         if ( !drawInnerBorder )
         {
             setCorner ( JScrollPane.LOWER_RIGHT_CORNER, null );


### PR DESCRIPTION
Fix is based on this discussion http://stackoverflow.com/questions/5583495/how-do-i-speed-up-the-scroll-speed-in-a-jscrollpane-when-using-the-mouse-wheel