### PR TITLE
Allow a combobox to have a wider popup

### DIFF
--- a/modules/ui/src/com/alee/laf/checkbox/SimpleCheckIcon.java
+++ b/modules/ui/src/com/alee/laf/checkbox/SimpleCheckIcon.java
@@ -121,7 +121,11 @@ public class SimpleCheckIcon extends CheckIcon
         if ( step > -1 )
         {
             final ImageIcon icon = enabled ? CHECK_STATES.get ( step ) : DISABLED_CHECK_STATES.get ( step );
-            g2d.drawImage ( icon.getImage (), x + w / 2 - getIconWidth () / 2, y + h / 2 - getIconHeight () / 2, null );
+
+            int xofs = ( w - getIconWidth () ) / 2 + ( ( w & 1 ) == 1 ? 1 : 0 );
+            int yofs = ( h - getIconHeight () ) / 2 + ( h > 16 ? ( ( h & 1 ) == 1 && h > 18 ? 2 : 1 ) : 0 ); 
+
+            g2d.drawImage ( icon.getImage (), x + xofs, y + yofs, null );
         }
     }
 }

--- a/modules/ui/src/com/alee/laf/combobox/WebComboBoxStyle.java
+++ b/modules/ui/src/com/alee/laf/combobox/WebComboBoxStyle.java
@@ -101,4 +101,9 @@ public final class WebComboBoxStyle
      * Whether should display scroll bar track or not.
      */
     public static boolean scrollBarTrackVisible = false;
+    
+    /**
+     * Whether the popup is allowed to be wider than the combobox or not.
+     */
+    public static boolean widerPopupAllowed = false;
 }

--- a/modules/ui/src/com/alee/laf/combobox/WebComboBoxUI.java
+++ b/modules/ui/src/com/alee/laf/combobox/WebComboBoxUI.java
@@ -73,6 +73,7 @@ public class WebComboBoxUI extends BasicComboBoxUI implements ShapeProvider, Bor
     private int shadeWidth = WebComboBoxStyle.shadeWidth;
     private boolean drawFocus = WebComboBoxStyle.drawFocus;
     private boolean mouseWheelScrollingEnabled = WebComboBoxStyle.mouseWheelScrollingEnabled;
+    private boolean widerPopupAllowed = WebComboBoxStyle.widerPopupAllowed;
     private boolean useFirstValueAsPrototype = false;
 
     private WebButton arrow = null;
@@ -442,6 +443,14 @@ public class WebComboBoxUI extends BasicComboBoxUI implements ShapeProvider, Bor
             private Point getPopupLocation ()
             {
                 final Dimension comboSize = comboBox.getSize ();
+                if (widerPopupAllowed)
+                {
+                    final Dimension prefSize = comboBox.getPreferredSize ();
+                    if (prefSize.width > comboSize.width)
+                    {
+                        comboSize.width = prefSize.width;
+                    }
+                }
                 comboSize.setSize ( comboSize.width - 2, getPopupHeightForRowCount ( comboBox.getMaximumRowCount () ) );
                 final Rectangle popupBounds = computePopupBounds ( 0, comboBox.getBounds ().height, comboSize.width, comboSize.height );
 
@@ -617,6 +626,16 @@ public class WebComboBoxUI extends BasicComboBoxUI implements ShapeProvider, Bor
     public void setMouseWheelScrollingEnabled ( final boolean enabled )
     {
         this.mouseWheelScrollingEnabled = enabled;
+    }
+
+    public boolean isWiderPopupAllowed ()
+    {
+        return widerPopupAllowed;
+    }
+
+    public void setWiderPopupAllowed ( final boolean allowed )
+    {
+        this.widerPopupAllowed = allowed;
     }
 
     /**


### PR DESCRIPTION
In some cases you can't allow a comboxbox to be its preferred size, because it wants to be as wide as the widest entry it has. As an example think about three comboboxes in a row, postal code, city and country.
You can not let the country combobox have it's preferred size, because it would be too wide only for a few countries with long names.  
WebComboBoxUI currently sets the wide of the popup exactly to the wide of the comboxbox.
With this change you can deside if the popup is allowed to be wide enouth to fit all its entries or not.

![combobox](https://cloud.githubusercontent.com/assets/10582708/5841907/db7c4300-a1a0-11e4-9608-d1b7e05d8467.png)