### PR TITLE
Fix for WebMenuItemUI

### DIFF
--- a/modules/ui/src/com/alee/laf/menu/WebMenuItemUI.java
+++ b/modules/ui/src/com/alee/laf/menu/WebMenuItemUI.java
@@ -495,6 +495,8 @@ public class WebMenuItemUI extends BasicMenuItemUI implements BorderMethods
                 final FontMetrics afm = menuItem.getFontMetrics ( acceleratorFont );
                 final int aw = afm.stringWidth ( accText );
 
+                GraphicsUtils.setupFont ( g, acceleratorFont );
+
                 x = ltr ? w - bi.right - aw : bi.left;
                 paintAcceleratorText ( g2d, menuItem, accText, afm, x, y, aw, ih, selected, ltr );
             }


### PR DESCRIPTION
![menudiff](https://cloud.githubusercontent.com/assets/10582708/5977463/974b1702-a898-11e4-9ec1-c1d3b78a8d66.png)

The first menu is after the fix, the second before.
In the second menu you see that the calculated rectangle for the accelerator text seems to be too small, 
but that's only because the normal font is used for drawing the accelerator text instead of the accelerator font.