### PR TITLE
Allow to set an accessory component on FileChoosers

### DIFF
--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooser.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooser.java
@@ -267,6 +267,16 @@ public class WebFileChooser extends JFileChooser implements LanguageMethods, Lan
     }
 
     /**
+     * Set the accessory component.
+     *
+     * @param accessory component
+     */
+    @Override
+    public void setAccessory ( JComponent c ) {
+        getWebUI ().setAccessory ( c );
+    }
+
+    /**
      * Sets approve button text type.
      *
      * @param approveText approve button text type

--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooserUI.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooserUI.java
@@ -160,6 +160,15 @@ public class WebFileChooserUI extends FileChooserUI
     }
 
     /**
+     * Set the accessory component.
+     *
+     * @param accessory component
+     */
+    public void setAccessory ( JComponent c ) {
+        fileChooser.add ( c, BorderLayout.EAST );
+    }
+
+    /**
      * Uninstalls UI from the specified component.
      *
      * @param c component with this UI


### PR DESCRIPTION
This allows to set a panel on the right side of the WebFileChosers. Maybe there could also be a possibility to add it somewhere else (west, north, south ?) but it seems to be a good default location to start with.

This is very useful to show a preview of images or some text information about the selected file in the FileChooser.