### PR TITLE
Add an interface to set an external icon generation method

### DIFF
--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
@@ -1055,6 +1055,14 @@ public class WebFileChooserPanel extends WebPanel
     }
 
     /**
+     * Returns the file list
+     */
+    public WebFileList getFileList ()
+    {
+        return fileList;
+    }
+
+    /**
      * Sets directory files view type
      *
      * @param viewType directory files view type


### PR DESCRIPTION
Weblaf displays icon thumbnails in filechoosers for different standard types of files (jpg, png, ...). In some specific cases, people have their own data format. For example, we have our own method to read our files and generate a thumbnail from the data contained in these files.

This patch adds an interface allowing to use an external method to define thumbnails in filechoosers.

- The usage is for the moment like this:
```
WebFileList fileList = getFileChooserPanel().getFileList();
WebFileListCellRenderer cellRenderer = fileList.getWebFileListCellRenderer();
cellRenderer.setIconCreator(new WebFileListCellRenderer.ExternalIconInterface() {
  @Override
  public Icon createIcon(File file) {
    final Icon icon = // Read file and generate Icon
    return icon; // Return Icon
  }
});
```

- Maybe you want to put this in the WebFileChooser class and provide the public API from there, I'll let you decide.
- I'm not a Java guru so my implementation is surely not the best. Not sure catching the NullPointerException is the best solution to know if the external method has been defined or not.
- The "official" API for JFileChoosers is to use setFileView() on the filechooser, but I don't know how that interacts with WebLaf (seems not to work, as you render the cells yourself). In this case maybe this PR is somewhat the wrong way of doing it.
