### PR TITLE
fixes #230 - allow file-chooser table sorting

### DIFF
--- a/modules/ui/src/com/alee/extended/filechooser/WebFileTable.java
+++ b/modules/ui/src/com/alee/extended/filechooser/WebFileTable.java
@@ -34,6 +34,9 @@ import java.util.List;
  * File table component.
  * It can either display specified folder content or custom list of files.
  *
+ * Note that row indices are always specified in terms of the table model
+ * and not in terms of the table view (which may change due to sorting).
+ *
  * @author Mikle Garin
  */
 
@@ -230,7 +233,7 @@ public class WebFileTable extends WebTable implements WebFileTableColumns
     public File getSelectedFile ()
     {
         final int row = getSelectedRow ();
-        return row != -1 ? getFileAtRow ( row ) : null;
+        return row != -1 ? getFileAtRow ( convertRowIndexToModel( row )) : null;
     }
 
     /**
@@ -244,7 +247,7 @@ public class WebFileTable extends WebTable implements WebFileTableColumns
         final List<File> selectedFiles = new ArrayList<File> ( selectedRows.length );
         for ( final int row : selectedRows )
         {
-            selectedFiles.add ( getFileAtRow ( row ) );
+            selectedFiles.add ( getFileAtRow ( convertRowIndexToModel( row )) );
         }
         return selectedFiles;
     }
@@ -277,7 +280,8 @@ public class WebFileTable extends WebTable implements WebFileTableColumns
      */
     public void setSelectedFile ( final File file, final boolean shouldScroll )
     {
-        setSelectedRow ( getFileTableModel ().getFileRow ( file ), shouldScroll );
+        final int row = getFileTableModel ().getFileRow(file);
+        setSelectedRow ( row == -1 ? -1 : convertRowIndexToView( row ) , shouldScroll );
     }
 
     /**
@@ -290,7 +294,8 @@ public class WebFileTable extends WebTable implements WebFileTableColumns
         clearSelection ();
         for ( final File file : files )
         {
-            addSelectedRow ( getFileTableModel ().getFileRow ( file ) );
+            final int row = getFileTableModel ().getFileRow(file);
+            if ( row != -1 ) addSelectedRow ( convertRowIndexToView( row ) );
         }
     }
 
@@ -315,7 +320,8 @@ public class WebFileTable extends WebTable implements WebFileTableColumns
         clearSelection ();
         for ( final File file : files )
         {
-            addSelectedRow ( getFileTableModel ().getFileRow ( file ) );
+            final int row = getFileTableModel ().getFileRow ( file );
+            if ( row != -1 ) addSelectedRow ( convertRowIndexToView( row ) );
         }
     }
 
@@ -326,7 +332,8 @@ public class WebFileTable extends WebTable implements WebFileTableColumns
      */
     public boolean editSelectedFileName ()
     {
-        return editFileNameAt ( getSelectedRow () );
+        final int row = getSelectedRow ();
+        return row != -1 && editFileNameAt ( convertRowIndexToModel( row ) );
     }
 
     /**
@@ -348,6 +355,7 @@ public class WebFileTable extends WebTable implements WebFileTableColumns
      */
     public boolean editFileNameAt ( final int row )
     {
-        return isColumnDisplayed ( NAME_COLUMN ) && editCellAt ( row, getColumnModel ().getColumnIndex ( NAME_COLUMN ) );
+        return row != 1 && isColumnDisplayed ( NAME_COLUMN ) &&
+                editCellAt ( convertRowIndexToView( row ), getColumnModel ().getColumnIndex ( NAME_COLUMN ) );
     }
 }

--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
@@ -51,7 +51,9 @@ import com.alee.laf.splitpane.WebSplitPane;
 import com.alee.laf.text.WebTextField;
 import com.alee.laf.toolbar.ToolbarStyle;
 import com.alee.laf.toolbar.WebToolBar;
+import com.alee.managers.hotkey.ButtonHotkeyRunnable;
 import com.alee.managers.hotkey.Hotkey;
+import com.alee.managers.hotkey.HotkeyManager;
 import com.alee.managers.language.LanguageManager;
 import com.alee.managers.language.data.TooltipWay;
 import com.alee.utils.*;
@@ -1018,7 +1020,8 @@ public class WebFileChooserPanel extends WebPanel
         } );
 
         approveButton = new WebButton ( "", APPROVE_ICON );
-        //        approveButton.addHotkey ( WebFileChooserPanel.this, Hotkey.CTRL_ENTER ).setHotkeyDisplayWay ( TooltipWay.up );
+        HotkeyManager.registerHotkey ( WebFileChooserPanel.this, approveButton, Hotkey.CTRL_ENTER,
+                new ButtonHotkeyRunnable ( approveButton, 200 ), false, TooltipWay.up );
         approveButton.setRolloverShine ( StyleConstants.highlightControlButtons );
         approveButton.setShineColor ( StyleConstants.greenHighlight );
         approveButton.putClientProperty ( GroupPanel.FILL_CELL, true );
@@ -1034,7 +1037,8 @@ public class WebFileChooserPanel extends WebPanel
 
         cancelButton = new WebButton ( "", CANCEL_ICON );
         cancelButton.setLanguage ( "weblaf.filechooser.cancel" );
-        //        cancelButton.addHotkey ( WebFileChooserPanel.this, Hotkey.ESCAPE ).setHotkeyDisplayWay ( TooltipWay.up );
+        HotkeyManager.registerHotkey ( WebFileChooserPanel.this, cancelButton, Hotkey.ESCAPE,
+                new ButtonHotkeyRunnable ( cancelButton, 200 ), false, TooltipWay.up );
         cancelButton.setRolloverShine ( StyleConstants.highlightControlButtons );
         cancelButton.setShineColor ( StyleConstants.redHighlight );
         cancelButton.putClientProperty ( GroupPanel.FILL_CELL, true );
@@ -1060,6 +1064,8 @@ public class WebFileChooserPanel extends WebPanel
             {
                 approveButton.setPreferredSize ( null );
                 cancelButton.setPreferredSize ( null );
+                approveButton.setToolTip ( approveButton.getText() );  // always the same as the label
+                cancelButton.setToolTip ( cancelButton.getText() );
                 SwingUtils.equalizeComponentsSize ( approveButton, cancelButton );
                 southPanel.revalidate ();
             }

--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
@@ -21,6 +21,8 @@ import com.alee.extended.drag.FileDragAndDropHandler;
 import com.alee.extended.filechooser.PathFieldListener;
 import com.alee.extended.filechooser.WebFileChooserField;
 import com.alee.extended.filechooser.WebFileTable;
+import com.alee.extended.filechooser.WebFileTableColumns;
+import com.alee.extended.filechooser.WebFileTableModel;
 import com.alee.extended.filechooser.WebPathField;
 import com.alee.extended.layout.ToolbarLayout;
 import com.alee.extended.layout.VerticalFlowLayout;
@@ -64,6 +66,7 @@ import com.alee.utils.text.FileNameProvider;
 
 import javax.swing.*;
 import javax.swing.event.*;
+import javax.swing.table.TableRowSorter;
 import javax.swing.tree.TreeSelectionModel;
 import java.awt.*;
 import java.awt.event.*;
@@ -789,7 +792,7 @@ public class WebFileChooserPanel extends WebPanel
             @Override
             public void editFinished ( final int index, final Object oldValue, final Object newValue )
             {
-                // Saving for futher selection
+                // Saving for future selection
                 final File file = ( ( FileElement ) newValue ).getFile ();
 
                 // Updating current view
@@ -869,7 +872,7 @@ public class WebFileChooserPanel extends WebPanel
             @Override
             public void editingStopped ( final ChangeEvent e )
             {
-                // Saving for futher selection
+                // Saving for future selection
                 final File file = fileTable.getSelectedFile ();
 
                 // Updating current view
@@ -886,6 +889,68 @@ public class WebFileChooserPanel extends WebPanel
                 // Do nothing
             }
         } );
+
+        final WebFileTableModel tableModel = fileTable.getFileTableModel ();
+        final TableRowSorter<WebFileTableModel> rowSorter = new TableRowSorter<WebFileTableModel> ( tableModel );
+        for ( int i = 0; i < tableModel.getColumnCount (); i++ ) {
+            final String columnId = tableModel.getColumnId ( i );
+            final Comparator<File> comp;
+            if ( columnId.equals ( WebFileTableColumns.NAME_COLUMN ) )
+            {
+                comp = GlobalConstants.FILE_COMPARATOR;
+            }
+            else if ( columnId.equals ( WebFileTableColumns.SIZE_COLUMN ))
+            {
+                comp = new Comparator<File> ()
+                {
+                    public int compare ( File a, File b )
+                    {
+                        final boolean ad = FileUtils.isDirectory ( a );
+                        final boolean bd = FileUtils.isDirectory ( b );
+                        if ( ad && bd ) return  0;
+                        if ( ad )       return -1;
+                        if ( bd )       return +1;
+                        final long al = a.length ();
+                        final long bl = b.length ();
+                        return al < bl ? -1 : ( al > bl ? +1 : 0 );
+                    }
+                };
+            }
+            else if ( columnId.equals ( WebFileTableColumns.EXTENSION_COLUMN ))
+            {
+                comp = new Comparator<File> ()
+                {
+                    public int compare ( File a, File b )
+                    {
+                        final boolean af = FileUtils.isFile ( a );
+                        final boolean bf = FileUtils.isFile ( b );
+                        final String as = af ? FileUtils.getFileExtPart ( a.getName (), true ) : "";
+                        final String bs = bf ? FileUtils.getFileExtPart ( b.getName (), true ) : "";
+                        return as.compareToIgnoreCase ( bs );
+                    }
+                };
+            }
+            else if ( columnId.equals ( WebFileTableColumns.MODIFICATION_DATE_COLUMN ))
+            {
+                comp = new Comparator<File> ()
+                {
+                    public int compare ( File a, File b )
+                    {
+                        final long al = a.lastModified ();
+                        final long bl = b.lastModified ();
+                        return al < bl ? -1 : ( al > bl ? +1 : 0 );
+                    }
+                };
+            } else {
+                comp = null;
+            }
+
+            if ( comp == null )
+                rowSorter.setSortable ( i, false );
+            else
+                rowSorter.setComparator ( i, comp );
+        }
+        fileTable.setRowSorter ( rowSorter );
 
         fileTableScroll = new WebScrollPane ( fileTable, true );
         fileTableScroll.getViewport ().setOpaque ( true );


### PR DESCRIPTION
This allows the table view of the file chooser to be sorted by name, extension, size and modification date.

I am using the default sorting order for the name column which lists directories first then files, so one can revert to default behaviour by sorting by name. I think this is the most sensible approach.