### PR TITLE
JColorChooser: palette not initializing correctly

### DIFF
--- a/modules/ui/src/com/alee/laf/colorchooser/WebColorChooserPanel.java
+++ b/modules/ui/src/com/alee/laf/colorchooser/WebColorChooserPanel.java
@@ -510,6 +510,7 @@ public class WebColorChooserPanel extends WebPanel implements DialogOptions
     private void updateView ( final Color color )
     {
         lineColorChooser.setColor ( color );
+        palette.setSideColor ( color );
         palette.setColor ( color );
     }
 


### PR DESCRIPTION
Before:
![2015-04-14 14_14_10-color manager](https://cloud.githubusercontent.com/assets/6352133/7136567/63c0cbc6-e2b2-11e4-9419-ea0f65eb1d85.png)

After:
![2015-04-14 14_14_55-color manager](https://cloud.githubusercontent.com/assets/6352133/7136576/705196ae-e2b2-11e4-82fe-6229a2438653.png)

Please review...