### PR TITLE
JPopupMenu: use PERPIXEL_TRANSPARENT for heavyweight popups when PERPIXEL_TRANSLUCENT is not available

### DIFF
--- a/modules/ui/src/com/alee/extended/window/WebPopOver.java
+++ b/modules/ui/src/com/alee/extended/window/WebPopOver.java
@@ -190,7 +190,7 @@ public class WebPopOver extends WebDialog implements Styleable, PopOverEventMeth
      */
     public WebPopOver ( final Window owner, final String title )
     {
-        super(owner, title);
+        super ( owner, title );
     }
 
     /**
@@ -224,8 +224,8 @@ public class WebPopOver extends WebDialog implements Styleable, PopOverEventMeth
         //        painter.setPopupStyle ( PopupStyle.simple );
 
         container = new WebPanel ( /*painter*/ );
-        container.setStyleId("pop-over");
-        setContentPane(container);
+        container.setStyleId ( "pop-over" );
+        setContentPane ( container );
 
         if ( !ProprietaryUtils.isWindowTransparencyAllowed () && ProprietaryUtils.isWindowShapeAllowed () )
         {

--- a/modules/ui/src/com/alee/extended/window/WebPopOver.java
+++ b/modules/ui/src/com/alee/extended/window/WebPopOver.java
@@ -26,6 +26,7 @@ import com.alee.managers.style.skin.web.WebPopOverPainter;
 import com.alee.managers.style.skin.web.WebPopupPainter;
 import com.alee.utils.CollectionUtils;
 import com.alee.utils.EventUtils;
+import com.alee.utils.ProprietaryUtils;
 import com.alee.utils.SwingUtils;
 import com.alee.utils.laf.Styleable;
 import com.alee.utils.swing.AncestorAdapter;
@@ -189,7 +190,7 @@ public class WebPopOver extends WebDialog implements Styleable, PopOverEventMeth
      */
     public WebPopOver ( final Window owner, final String title )
     {
-        super ( owner, title );
+        super(owner, title);
     }
 
     /**
@@ -223,8 +224,25 @@ public class WebPopOver extends WebDialog implements Styleable, PopOverEventMeth
         //        painter.setPopupStyle ( PopupStyle.simple );
 
         container = new WebPanel ( /*painter*/ );
-        container.setStyleId ( "pop-over" );
-        setContentPane ( container );
+        container.setStyleId("pop-over");
+        setContentPane(container);
+
+        if ( !ProprietaryUtils.isWindowTransparencyAllowed () && ProprietaryUtils.isWindowShapeAllowed () )
+        {
+            final ComponentAdapter resizeAdapter = new ComponentAdapter ()
+            {
+                @Override
+                public void componentResized ( ComponentEvent e )
+                {
+                    if ( getPainter () != null )
+                    {
+                        Rectangle bounds = getBounds (); ++bounds.width; ++bounds.height;
+                        ProprietaryUtils.setWindowShape ( WebPopOver.this, getPainter ().provideShape ( container, bounds ) );
+                    }
+                }
+            };
+            addComponentListener ( resizeAdapter );
+        }
 
         final ComponentMoveAdapter moveAdapter = new ComponentMoveAdapter ()
         {

--- a/modules/ui/src/com/alee/laf/menu/WebPopupMenuUI.java
+++ b/modules/ui/src/com/alee/laf/menu/WebPopupMenuUI.java
@@ -23,6 +23,7 @@ import com.alee.global.StyleConstants;
 import com.alee.laf.WebLookAndFeel;
 import com.alee.managers.style.StyleManager;
 import com.alee.managers.style.skin.web.PopupStyle;
+import com.alee.managers.style.skin.web.WebPopupPainter;
 import com.alee.utils.LafUtils;
 import com.alee.utils.ProprietaryUtils;
 import com.alee.utils.SwingUtils;
@@ -97,7 +98,7 @@ public class WebPopupMenuUI extends BasicPopupMenuUI implements SwingConstants, 
         super.installUI ( c );
 
         // Default settings
-        transparent = ProprietaryUtils.isWindowTransparencyAllowed ();
+        transparent = ProprietaryUtils.isWindowTransparencyAllowed () || ProprietaryUtils.isWindowShapeAllowed ();
         SwingUtils.setOrientation ( popupMenu );
         SwingUtils.setHandlesEnableStateMark ( popupMenu );
 
@@ -180,6 +181,12 @@ public class WebPopupMenuUI extends BasicPopupMenuUI implements SwingConstants, 
                         if ( SwingUtils.isHeavyWeightWindow ( ancestor ) )
                         {
                             ProprietaryUtils.setWindowOpaque ( ancestor, false );
+                            if ( painter instanceof WebPopupPainter && !ProprietaryUtils.isWindowTransparencyAllowed () )
+                            {
+                                Rectangle bounds = ancestor.getBounds(); ++bounds.width; ++bounds.height;
+                                Shape shape = ( ( WebPopupPainter ) painter ).provideShape ( popupMenu, bounds );
+                                ProprietaryUtils.setWindowShape ( ancestor, shape );
+                            }
                         }
                     }
                     else
@@ -188,6 +195,7 @@ public class WebPopupMenuUI extends BasicPopupMenuUI implements SwingConstants, 
                         if ( SwingUtils.isHeavyWeightWindow ( ancestor ) )
                         {
                             ProprietaryUtils.setWindowOpaque ( ancestor, true );
+                            ProprietaryUtils.setWindowShape ( ancestor, null );
                         }
                     }
                 }

--- a/modules/ui/src/com/alee/laf/menu/WebPopupMenuUI.java
+++ b/modules/ui/src/com/alee/laf/menu/WebPopupMenuUI.java
@@ -181,7 +181,7 @@ public class WebPopupMenuUI extends BasicPopupMenuUI implements SwingConstants, 
                         if ( SwingUtils.isHeavyWeightWindow ( ancestor ) )
                         {
                             ProprietaryUtils.setWindowOpaque ( ancestor, false );
-                            if ( painter instanceof WebPopupPainter && !ProprietaryUtils.isWindowTransparencyAllowed () )
+                            if ( painter instanceof WebPopupPainter && !ProprietaryUtils.isWindowTransparencyAllowed () && ProprietaryUtils.isWindowShapeAllowed () )
                             {
                                 Rectangle bounds = ancestor.getBounds(); ++bounds.width; ++bounds.height;
                                 Shape shape = ( ( WebPopupPainter ) painter ).provideShape ( popupMenu, bounds );

--- a/modules/ui/src/com/alee/managers/style/skin/web/WebPopupPainter.java
+++ b/modules/ui/src/com/alee/managers/style/skin/web/WebPopupPainter.java
@@ -368,7 +368,7 @@ public class WebPopupPainter<E extends JComponent> extends AbstractPainter<E> im
     @Override
     public Shape provideShape ( final E component, final Rectangle bounds )
     {
-        return getBorderShape ( component, component.getSize (), false );
+        return getBorderShape ( component, bounds.getSize(), false );
     }
 
     /**
@@ -600,7 +600,7 @@ public class WebPopupPainter<E extends JComponent> extends AbstractPainter<E> im
                     {
                         return createSimpleShape ( popup, popupSize, fill );
                     }
-                }, getCachedShapeSettings ( popup ) );
+                }, getCachedShapeSettings ( popup, popupSize ) );
             }
             case dropdown:
             {
@@ -611,7 +611,7 @@ public class WebPopupPainter<E extends JComponent> extends AbstractPainter<E> im
                     {
                         return createDropdownShape ( popup, popupSize, fill );
                     }
-                }, getCachedShapeSettings ( popup ) );
+                }, getCachedShapeSettings ( popup, popupSize ) );
             }
             default:
             {
@@ -624,11 +624,12 @@ public class WebPopupPainter<E extends JComponent> extends AbstractPainter<E> im
      * Returns an array of shape settings cached along with the shape.
      *
      * @param popup popup component
+     * @param popupSize popup size
      * @return an array of shape settings cached along with the shape
      */
-    protected Object[] getCachedShapeSettings ( final E popup )
+    protected Object[] getCachedShapeSettings ( final E popup, final Dimension popupSize )
     {
-        return new Object[]{ round, shadeWidth, cornerWidth, cornerSide, relativeCorner, cornerAlignment, popup.getSize (),
+        return new Object[]{ round, shadeWidth, cornerWidth, cornerSide, relativeCorner, cornerAlignment, popupSize,
                 popup.getComponentOrientation ().isLeftToRight () };
     }
 
@@ -774,7 +775,7 @@ public class WebPopupPainter<E extends JComponent> extends AbstractPainter<E> im
             {
                 return createDropdownCornerShape ( popupMenu, menuSize, fill );
             }
-        }, getCachedShapeSettings ( popupMenu ) );
+        }, getCachedShapeSettings ( popupMenu, menuSize ) );
     }
 
     /**


### PR DESCRIPTION
On Linux, Java per-pixel translucency support is often disabled, depending on the window manager and graphics card driver installed. In this case, WEBLAF reverts to a fully opaque look for both heavy- and lightweight popups.

Heavyweight popup:
![2015-04-16 10_39_57-seam09_aps - ufa atprepare](https://cloud.githubusercontent.com/assets/6352133/7177207/154a9674-e425-11e4-87ca-8a4b80490bfc.png)

Lightweight popup:
![2015-04-16 10_40_17-seam09_aps - ufa atprepare](https://cloud.githubusercontent.com/assets/6352133/7177213/2379190a-e425-11e4-9f33-74395a7829a2.png)

Kinda uncool, especially the opaque rounded corners...

At the same time, per-pixel transparency (shaped windows) is always supported (tested it with a lot of different Linux versions/configurations). This update makes use of per-pixel transparency for heavyweight popups when per-pixel translucency is not available/disabled.

Heavyweight popup:
![2015-04-16 10_44_57-seam09_aps - ufa atprepare](https://cloud.githubusercontent.com/assets/6352133/7177290/bb0dad3a-e425-11e4-9b0b-d2a153057fb2.png)

Lightweight popup:
![2015-04-16 10_45_20-seam09_aps - ufa atprepare](https://cloud.githubusercontent.com/assets/6352133/7177300/c3c66b60-e425-11e4-9d6a-a1450be9febc.png)

Much better, imho. The only difference to translucency mode is the absence of the drop shadow and the opacity of heavyweight popups, lightweight popups look the same.

This behavior is disabled by default; to enable, use 

      ProprietaryUtils.setWindowShapeAllowed(true);

To test it under Windows, use

      ProprietaryUtils.setWindowTransparencyAllowed(false);
      ProprietaryUtils.setWindowShapeAllowed(true);

WBR
Gregory