### PR TITLE
Set clip shape producer also in constructor

### DIFF
--- a/modules/ui/src/com/alee/extended/progress/WebProgressOverlay.java
+++ b/modules/ui/src/com/alee/extended/progress/WebProgressOverlay.java
@@ -58,6 +58,9 @@ public class WebProgressOverlay extends WebOverlay
     {
         super ( component );
         initializeProgressLayer ();
+
+        // Default Web clip shape producer
+        setClipShapeProducer ( component != null ? new WebShapeProducer ( component ) : null );
     }
 
     protected void initializeProgressLayer ()


### PR DESCRIPTION
When using the setComponent() method in WebProgressOverlay, the clip shape producer is set.

This was not done when passing the component through the constructor, resulting on wrong clipping (The progress overlay was also painted outside of the button):

![clipping](https://cloud.githubusercontent.com/assets/3406519/8699286/cc91ab26-2b04-11e5-8f5e-f4f1836ad4c8.png)

I made the change against master, don't know if this needs to be ported to the styling branch.
