### PR TITLE
Proper handling of null JTableHeaders and borders on startup

### DIFF
--- a/modules/ui/src/com/alee/laf/table/WebTableUI.java
+++ b/modules/ui/src/com/alee/laf/table/WebTableUI.java
@@ -34,6 +34,8 @@ import com.alee.utils.swing.DataRunnable;
 import javax.swing.*;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicTableUI;
+import javax.swing.table.JTableHeader;
+
 import java.awt.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -122,7 +124,11 @@ public class WebTableUI extends BasicTableUI implements Styleable, ShapeProvider
             @Override
             public void propertyChange ( final PropertyChangeEvent evt )
             {
-                StyleId.tableHeader.at ( table ).set ( table.getTableHeader () );
+            	JTableHeader header = table.getTableHeader ();
+            	if (header != null)
+            	{
+            		StyleId.tableHeader.at ( table ).set ( table.getTableHeader () );
+            	}
             }
         };
         table.addPropertyChangeListener ( WebLookAndFeel.TABLE_HEADER_PROPERTY, propertyChangeListener );

--- a/modules/ui/src/com/alee/painter/AbstractPainter.java
+++ b/modules/ui/src/com/alee/painter/AbstractPainter.java
@@ -340,6 +340,9 @@ public abstract class AbstractPainter<E extends JComponent, U extends ComponentU
     public Dimension getPreferredSize ()
     {
         final Insets borders = getCompleteBorder ();
+        if ( borders == null ) {
+        	return new Dimension ();
+        }
         return new Dimension ( borders.left + borders.right, borders.top + borders.bottom );
     }
 


### PR DESCRIPTION
For whatever reason, my application had a couple of stack traces on startup and when displaying modals.  This pull request addresses two of them.

1. `JTable.getTableHeader()` is allowed to return `null`, as per [JTable.setTableHeader's Javadoc](https://docs.oracle.com/javase/7/docs/api/javax/swing/JTable.html#setTableHeader(javax.swing.table.JTableHeader).  Thus `WebTableUI.propertyChange()` should guard against that.

2. `AbstractPainter.getCompleteBorder()` can return null if the `JComponent` is honoring user borders.  Thus `AbstractPainter.getPreferredSize()` should check for `null` insets.