### PR TITLE
sort tabs in style-editor

### DIFF
--- a/modules/ui/src/com/alee/extended/style/StyleEditor.java
+++ b/modules/ui/src/com/alee/extended/style/StyleEditor.java
@@ -691,13 +691,23 @@ public class StyleEditor extends WebFrame
         loadSkinSources ( xmlContent, xmlNames, xmlFiles );
 
         // Creating editor tabs
-        editors = new ArrayList<WebSyntaxArea> ( xmlContent.size () );
+        final int numTabs = xmlContent.size ();
+        editors = new ArrayList<WebSyntaxArea> ( numTabs );
+        final List<String> sortedNames = new ArrayList<String> ( numTabs );
         for ( int i = 0; i < xmlContent.size (); i++ )
         {
             final WebPanel tabContent = new WebPanel ();
             tabContent.add ( new TabContentSeparator (), BorderLayout.NORTH );
             tabContent.add ( createSingleXmlEditor ( xmlContent.get ( i ), xmlFiles.get ( i ) ), BorderLayout.CENTER );
-            editorTabs.addTab ( xmlNames.get ( i ), tabContent );
+            final String name = xmlNames.get ( i );
+            int j = 0;
+            while ( j < i )
+            {
+                if ( sortedNames.get ( j ).compareTo ( name ) > 0 ) break;
+                j++;
+            }
+            editorTabs.insertTab ( name, null, tabContent, null, j );
+            sortedNames.add ( j, name );
             editorTabs.setIconAt ( i, tabIcon );
         }
 


### PR DESCRIPTION
Especially when working on a derived skin, the number of tabs in the `StyleEditor` becomes very large, making it difficult to find a particular component. This change sorts the tab alphabetically.