### PR TITLE
add 'noshade' option to label.

### DIFF
--- a/modules/ui/src/com/alee/skin/web/resources/label.xml
+++ b/modules/ui/src/com/alee/skin/web/resources/label.xml
@@ -22,6 +22,13 @@
         </painter>
     </style>
 
+    <!-- Label without text shade -->
+    <style type="label" id="noshade">
+        <painter>
+            <drawShade>false</drawShade>
+        </painter>
+    </style>
+
     <!-- Vertical text -->
     <style type="label" id="vertical">
         <painter>


### PR DESCRIPTION
although the default skin does not add a shade to the regular label,
other skin might do. then for an application in order to declare a
'plain' label without shade, it should be possible to call
`putClientProperty("styleId", "noshade")`. this will currently
throw an exception with the default skin because no such style
exists.