### PR TITLE
Don't cache not-yet-existant files as not being a directory

### DIFF
--- a/modules/core/src/com/alee/utils/FileUtils.java
+++ b/modules/core/src/com/alee/utils/FileUtils.java
@@ -2447,7 +2447,7 @@ public final class FileUtils
      */
     public static boolean isDirectory ( final File file )
     {
-        if ( file == null )
+        if ( file == null || !file.exists() )
         {
             return false;
         }


### PR DESCRIPTION
This triggered a bug in our code where a not-yet-existing file entered in a `WebPathField` would be cached in the `isDirectoryCash` before the user confirmed creation. Subsequently it would be displayed as a file in `WebFileChooser`s