### PR TITLE
memory and performance issue. the rendererPane need to be cleaned aft…

### DIFF
--- a/modules/ui/src/com/alee/laf/table/WebTableHeaderUI.java
+++ b/modules/ui/src/com/alee/laf/table/WebTableHeaderUI.java
@@ -163,6 +163,9 @@ public class WebTableHeaderUI extends BasicTableHeaderUI
             // Header cell
             paintCell ( g, draggedCellRect, draggedColumnIndex, draggedColumn, draggedColumn, cm );
         }
+
+        // Remove all components in the rendererPane.
+        rendererPane.removeAll();
     }
 
     public static Paint createBackgroundPaint ( final int x1, final int y1, final int x2, final int y2 )


### PR DESCRIPTION
I found in issue on  WebTableHeaderUI, after using the rendererPane it needs to be cleaned.
In my application, removing and attaching a panel with a table couses a memory and performance problem in the  JCompoenent addNotify methode. The root cause was that the CellRenderePane hat 70k of child components.