### PR TITLE
Allow to hide hidden files in WebPathField

### DIFF
--- a/modules/ui/src/com/alee/extended/pathfield/WebPathField.java
+++ b/modules/ui/src/com/alee/extended/pathfield/WebPathField.java
@@ -102,6 +102,11 @@ public class WebPathField extends WebPanel
     protected WebButton myComputer = null;
 
     /**
+     * Whether hidden files are displayed or not.
+     */
+    protected boolean showHiddenFiles = false;
+
+    /**
      * Autocomplete.
      */
     protected boolean autocompleteEnabled = true;
@@ -427,7 +432,14 @@ public class WebPathField extends WebPanel
                 final List<File> similar = getSimilarFileChildren ( parent, t.substring ( beginIndex ) );
                 if ( similar != null && similar.size () > 0 )
                 {
-                    updateList ( similar );
+                    final List<File> filteredList = new ArrayList<File>();
+                    for (File file : similar) {
+                        if ( showHiddenFiles || !FileUtils.isHidden ( file ) )
+                        {
+                            filteredList.add ( file );
+                        }
+                    }
+                    updateList ( filteredList );
                 }
                 else
                 {
@@ -623,6 +635,26 @@ public class WebPathField extends WebPanel
         this.autocompleteEnabled = autocompleteEnabled;
     }
 
+    /**
+     * Returns whether hidden files are displayed or not.
+     *
+     * @return true if should display hidden files, false otherwise
+     */
+    public boolean isShowHiddenFiles ()
+    {
+        return showHiddenFiles;
+    }
+
+    /**
+     * Sets whether hidden files should be displayed or not.
+     *
+     * @param showHiddenFiles whether should display hidden files or not
+     */
+    public void setShowHiddenFiles ( final boolean showHiddenFiles ) {
+        this.showHiddenFiles = showHiddenFiles;
+    }
+
+
     public AbstractFileFilter getFileFilter ()
     {
         return fileFilter;
@@ -737,7 +769,17 @@ public class WebPathField extends WebPanel
 
                 int childrenCount = 0;
                 final WebPopupMenu menu = new WebPopupMenu ();
-                final File[] files = FileUtils.sortFiles ( getFileChildren ( file ) );
+                final File[] fileChildren = getFileChildren(file);
+                final List<File> filteredFileChildren = new ArrayList<File>();
+                for (File fileChild : fileChildren)
+                {
+                    if ( showHiddenFiles || !FileUtils.isHidden ( fileChild ) )
+                    {
+                        filteredFileChildren.add ( fileChild );
+                    }
+                }
+
+                final File[] files = FileUtils.sortFiles ( filteredFileChildren.toArray ( new File[ filteredFileChildren.size() ] ) );
                 if ( files != null )
                 {
                     for ( final File root : files )

--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
@@ -166,7 +166,7 @@ public class WebFileChooserPanel extends WebPanel
     protected FileSelectionMode fileSelectionMode = FileSelectionMode.filesAndDirectories;
 
     /**
-     * Whether should display hidden files or not.
+     * Whether hidden files are displayed or not.
      */
     protected boolean showHiddenFiles = false;
 
@@ -474,6 +474,7 @@ public class WebFileChooserPanel extends WebPanel
         } );
 
         pathField = new WebPathField( StyleId.filechooserPathField.at ( toolBar ) );
+        pathField.setShowHiddenFiles( showHiddenFiles );
         pathFieldListener = new PathFieldListener ()
         {
             @Override
@@ -2140,7 +2141,7 @@ public class WebFileChooserPanel extends WebPanel
     }
 
     /**
-     * Sets whether should display hidden files or not.
+     * Returns whether hidden files are displayed or not.
      *
      * @return true if should display hidden files, false otherwise
      */
@@ -2150,7 +2151,7 @@ public class WebFileChooserPanel extends WebPanel
     }
 
     /**
-     * Sets whether should display hidden files or not.
+     * Sets whether hidden files should be displayed or not.
      *
      * @param showHiddenFiles whether should display hidden files or not
      */
@@ -2159,6 +2160,7 @@ public class WebFileChooserPanel extends WebPanel
         this.showHiddenFiles = showHiddenFiles;
         updateDirectoryComponentFilters ();
         updateFileComponentFilters ();
+        pathField.setShowHiddenFiles( showHiddenFiles );
     }
 
     /**


### PR DESCRIPTION
When used in combination with the WebFileChooser class,
the showHiddenFiles state is propagated to the WebPathField too.