### PR TITLE
Fix NPE in WebPathField

### DIFF
--- a/modules/ui/src/com/alee/extended/pathfield/WebPathField.java
+++ b/modules/ui/src/com/alee/extended/pathfield/WebPathField.java
@@ -772,11 +772,14 @@ public class WebPathField extends WebPanel
                 final WebPopupMenu menu = new WebPopupMenu ();
                 final File[] fileChildren = getFileChildren ( file );
                 final List<File> filteredFileChildren = new ArrayList<File> ();
-                for ( final File fileChild : fileChildren )
+                if ( fileChildren != null )
                 {
-                    if ( showHiddenFiles || !FileUtils.isHidden ( fileChild ) )
+                    for ( final File fileChild : fileChildren )
                     {
-                        filteredFileChildren.add ( fileChild );
+                        if ( showHiddenFiles || !FileUtils.isHidden ( fileChild ) )
+                        {
+                            filteredFileChildren.add ( fileChild );
+                        }
                     }
                 }
 


### PR DESCRIPTION
This error was introduced by the changes made in
072af5606fd2be039cae31fe1ffc99d479fa4149

The fileChildren array could be null. In this case,
the filtered list will now stay empty.