### PR TITLE
Make filetable accessible in filechooser

### DIFF
--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
@@ -1150,6 +1150,16 @@ public class WebFileChooserPanel extends WebPanel
     }
 
     /**
+     * Returns file table.
+     *
+     * @return file table
+     */
+    public WebFileTable getFileTable ()
+    {
+        return fileTable;
+    }
+
+    /**
      * Returns directory files view type.
      *
      * @return directory files view type


### PR DESCRIPTION
This allows to get the current sorting order if
it needs to be read from outside of the filechooser.
It also allows to set the change the sort keys
to change the sorting order of the table,
using getFileTable().getRowSorter().setSortKeys().