### PR TITLE
Search icons in the latest loaded IconSet first

### DIFF
--- a/modules/ui/src/com/alee/managers/icon/IconManager.java
+++ b/modules/ui/src/com/alee/managers/icon/IconManager.java
@@ -27,6 +27,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 
 /**
@@ -178,9 +179,9 @@ public final class IconManager
             }
 
             // Checking icon sets
-            for ( final IconSet iconSet : iconSets )
-            {
-                icon = iconSet.getIcon ( id );
+            ListIterator<IconSet> iter = iconSets.listIterator ( iconSets.size () );
+            while ( iter.hasPrevious () ) {
+                icon = iter.previous ().getIcon ( id );
                 if ( icon != null )
                 {
                     return icon;


### PR DESCRIPTION
This allows to override Weblaf icons by providing
custom IconSets. The list of IconSet is parsed
the other way round, starting at the end.