### PR TITLE
Update WebComboBoxUI.java

### DIFF
--- a/modules/ui/src/com/alee/laf/combobox/WebComboBoxUI.java
+++ b/modules/ui/src/com/alee/laf/combobox/WebComboBoxUI.java
@@ -463,7 +463,7 @@ public class WebComboBoxUI extends BasicComboBoxUI implements ShapeProvider, Bor
             @Override
             public void show ()
             {
-                if ( !buttonEnabled )
+                if ( !buttonEnabled || !buttonVisible )
                 {
                     return;
                 }

--- a/modules/ui/src/com/alee/laf/combobox/WebComboBoxUI.java
+++ b/modules/ui/src/com/alee/laf/combobox/WebComboBoxUI.java
@@ -81,6 +81,8 @@ public class WebComboBoxUI extends BasicComboBoxUI implements ShapeProvider, Bor
     protected boolean mouseWheelScrollingEnabled = WebComboBoxStyle.mouseWheelScrollingEnabled;
     protected boolean widerPopupAllowed = WebComboBoxStyle.widerPopupAllowed;
     protected boolean useFirstValueAsPrototype = false;
+    protected boolean buttonEnabled = true;
+    protected boolean buttonVisible = true;
 
     protected WebButton arrow = null;
     protected MouseWheelListener mouseWheelListener = null;
@@ -331,6 +333,7 @@ public class WebComboBoxUI extends BasicComboBoxUI implements ShapeProvider, Bor
         super.configureArrowButton ();
         if ( arrowButton != null )
         {
+            arrowButton.setEnabled ( buttonEnabled );
             arrowButton.setFocusable ( false );
         }
     }
@@ -460,6 +463,11 @@ public class WebComboBoxUI extends BasicComboBoxUI implements ShapeProvider, Bor
             @Override
             public void show ()
             {
+                if ( !buttonEnabled )
+                {
+                    return;
+                }
+
                 comboBox.firePopupMenuWillBecomeVisible ();
 
                 setListSelection ( comboBox.getSelectedIndex () );
@@ -677,6 +685,36 @@ public class WebComboBoxUI extends BasicComboBoxUI implements ShapeProvider, Bor
     public void setWiderPopupAllowed ( final boolean allowed )
     {
         this.widerPopupAllowed = allowed;
+    }
+
+    public boolean isButtonEnabled ()
+    {
+        return buttonEnabled;
+    }
+
+    public void setButtonEnabled ( final boolean enabled )
+    {
+        this.buttonEnabled = enabled;
+
+        if ( arrow != null )
+        {
+            arrow.setEnabled ( enabled );
+        }
+    }
+
+    public boolean isButtonVisible ()
+    {
+        return buttonVisible;
+    }
+
+    public void setButtonVisible ( final boolean visible )
+    {
+        this.buttonVisible = visible;
+
+        if ( arrow != null )
+        {
+            comboBox.revalidate ();
+        }
     }
 
     /**
@@ -1028,7 +1066,7 @@ public class WebComboBoxUI extends BasicComboBoxUI implements ShapeProvider, Bor
             {
                 final Insets insets = getInsets ();
                 final int buttonHeight = height - ( insets.top + insets.bottom );
-                final int buttonWidth = arrowButton.getPreferredSize ().width;
+                final int buttonWidth = buttonVisible ? arrowButton.getPreferredSize ().width : 0;
                 if ( cb.getComponentOrientation ().isLeftToRight () )
                 {
                     arrowButton.setBounds ( width - ( insets.right + buttonWidth ), insets.top, buttonWidth, buttonHeight );


### PR DESCRIPTION
For a combobox it can be nice to have the opportunity to hide or to disable the button for the popup.
This can be useful for a input history list for example, so if you have no input history, you only see a normal input field. If you have a input history, you see a combobox with a dropdown list.
Or you always see a combobox, but the button is disabled if no history is available und the popup would be empty.

With this request you have four more methods in WebComboBoxUI to control this behavior
(isButtonEnabled, setButtonEnabled, isButtonVisible, setButtonVisible).