### PR TITLE
[Styling] Request of code updates for item #419

### DIFF
--- a/modules/core/src/com/alee/utils/FileUtils.java
+++ b/modules/core/src/com/alee/utils/FileUtils.java
@@ -2643,6 +2643,11 @@ public final class FileUtils
             displayFileNameCache.put ( absolutePath, name );
             return name;
         }
+        else if ( !file.exists () && file.getName() != null )
+        {
+        	displayFileNameCache.put ( absolutePath, file.getName() );
+            return file.getName();
+        }
         else
         {
             return "";

--- a/modules/core/src/com/alee/utils/FileUtils.java
+++ b/modules/core/src/com/alee/utils/FileUtils.java
@@ -2643,9 +2643,9 @@ public final class FileUtils
             displayFileNameCache.put ( absolutePath, name );
             return name;
         }
-        else if ( !file.exists () && file.getName() != null )
+        else if ( !file.exists () && file.getName () != null )
         {
-        	displayFileNameCache.put ( absolutePath, file.getName() );
+        	displayFileNameCache.put ( absolutePath, file.getName () );
             return file.getName();
         }
         else

--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooser.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooser.java
@@ -311,6 +311,7 @@ public class WebFileChooser extends JFileChooser
     	}
     	else
     	{
+    		this.getFileChooserPanel ().getSelectedFilesViewField ().setSelectedFile( file );;
     		this.getFileChooserPanel ().getSelectedFilesTextField ().setText ( file.getName () );
     		if ( file.getParent () != null && new File ( file.getParent () ).exists () ) 
     		{

--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooser.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooser.java
@@ -305,16 +305,16 @@ public class WebFileChooser extends JFileChooser
     */
     public void setSelectedFile ( final File file )
     {
-    	if ( file == null || file.exists() )
+    	if ( file == null || file.exists () )
     	{
     		super.setSelectedFile ( file );
     	}
     	else
     	{
     		this.getFileChooserPanel ().getSelectedFilesTextField ().setText ( file.getName () );
-    		if ( file.getParent() != null && new File ( file.getParent () ).exists () ) 
+    		if ( file.getParent () != null && new File ( file.getParent () ).exists () ) 
     		{
-    			this.setCurrentDirectory( file.getParent () );
+    			this.setCurrentDirectory ( file.getParent () );
     		}
     	}
     }

--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooser.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooser.java
@@ -297,6 +297,27 @@ public class WebFileChooser extends JFileChooser
     {
         setSelectedFile ( path != null ? new File ( path ) : null );
     }
+    
+    /**
+    * Sets currently selected file.
+    *
+    * @param the file to select
+    */
+    public void setSelectedFile ( final File file )
+    {
+    	if ( file == null || file.exists() )
+    	{
+    		super.setSelectedFile ( file );
+    	}
+    	else
+    	{
+    		this.getFileChooserPanel ().getSelectedFilesTextField ().setText ( file.getName () );
+    		if ( file.getParent() != null && new File ( file.getParent () ).exists () ) 
+    		{
+    			this.setCurrentDirectory( file.getParent () );
+    		}
+    	}
+    }
 
     /**
      * Returns file chooser panel.

--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooser.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooser.java
@@ -17,10 +17,35 @@
 
 package com.alee.laf.filechooser;
 
+import java.awt.Component;
+import java.awt.HeadlessException;
+import java.awt.Image;
+import java.awt.Insets;
+import java.awt.Shape;
+import java.awt.Window;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+import javax.swing.ImageIcon;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.filechooser.FileSystemView;
+
 import com.alee.managers.language.LanguageManager;
 import com.alee.managers.language.LanguageMethods;
 import com.alee.managers.language.updaters.LanguageUpdater;
-import com.alee.managers.style.*;
+import com.alee.managers.style.MarginMethods;
+import com.alee.managers.style.MarginMethodsImpl;
+import com.alee.managers.style.PaddingMethods;
+import com.alee.managers.style.PaddingMethodsImpl;
+import com.alee.managers.style.ShapeMethods;
+import com.alee.managers.style.ShapeMethodsImpl;
+import com.alee.managers.style.Skin;
+import com.alee.managers.style.StyleId;
+import com.alee.managers.style.StyleListener;
+import com.alee.managers.style.StyleManager;
+import com.alee.managers.style.Styleable;
 import com.alee.painter.Paintable;
 import com.alee.painter.Painter;
 import com.alee.utils.CollectionUtils;
@@ -28,13 +53,6 @@ import com.alee.utils.FileUtils;
 import com.alee.utils.ImageUtils;
 import com.alee.utils.SwingUtils;
 import com.alee.utils.swing.Customizer;
-
-import javax.swing.*;
-import javax.swing.filechooser.FileSystemView;
-import java.awt.*;
-import java.io.File;
-import java.util.List;
-import java.util.Map;
 
 /**
  * {@link JFileChooser} extension class.
@@ -295,7 +313,28 @@ public class WebFileChooser extends JFileChooser
      */
     public void setSelectedFile ( final String path )
     {
-        setSelectedFile ( path != null ? new File ( path ) : null );
+    	setSelectedFile ( path != null ? new File ( path ) : null ); 
+    }
+    
+    /**
+     * Sets currently selected file.
+     *
+     * @param the file to select
+     */
+    public void setSelectedFile ( final File file )
+    {
+    	if ( file == null || file.exists() )
+    	{
+    		super.setSelectedFile ( file );
+    	}
+    	else
+    	{
+    		this.getFileChooserPanel ().getSelectedFilesTextField ().setText ( file.getName() );
+    		if ( file.getParent() != null && new File ( file.getParent() ).exists() ) 
+    		{
+    			this.setCurrentDirectory( file.getParent() );
+    		}
+    	}
     }
 
     /**

--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooser.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooser.java
@@ -17,35 +17,10 @@
 
 package com.alee.laf.filechooser;
 
-import java.awt.Component;
-import java.awt.HeadlessException;
-import java.awt.Image;
-import java.awt.Insets;
-import java.awt.Shape;
-import java.awt.Window;
-import java.io.File;
-import java.util.List;
-import java.util.Map;
-
-import javax.swing.ImageIcon;
-import javax.swing.JDialog;
-import javax.swing.JFileChooser;
-import javax.swing.filechooser.FileSystemView;
-
 import com.alee.managers.language.LanguageManager;
 import com.alee.managers.language.LanguageMethods;
 import com.alee.managers.language.updaters.LanguageUpdater;
-import com.alee.managers.style.MarginMethods;
-import com.alee.managers.style.MarginMethodsImpl;
-import com.alee.managers.style.PaddingMethods;
-import com.alee.managers.style.PaddingMethodsImpl;
-import com.alee.managers.style.ShapeMethods;
-import com.alee.managers.style.ShapeMethodsImpl;
-import com.alee.managers.style.Skin;
-import com.alee.managers.style.StyleId;
-import com.alee.managers.style.StyleListener;
-import com.alee.managers.style.StyleManager;
-import com.alee.managers.style.Styleable;
+import com.alee.managers.style.*;
 import com.alee.painter.Paintable;
 import com.alee.painter.Painter;
 import com.alee.utils.CollectionUtils;
@@ -53,6 +28,13 @@ import com.alee.utils.FileUtils;
 import com.alee.utils.ImageUtils;
 import com.alee.utils.SwingUtils;
 import com.alee.utils.swing.Customizer;
+
+import javax.swing.*;
+import javax.swing.filechooser.FileSystemView;
+import java.awt.*;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
 
 /**
  * {@link JFileChooser} extension class.
@@ -313,28 +295,7 @@ public class WebFileChooser extends JFileChooser
      */
     public void setSelectedFile ( final String path )
     {
-    	setSelectedFile ( path != null ? new File ( path ) : null ); 
-    }
-    
-    /**
-     * Sets currently selected file.
-     *
-     * @param the file to select
-     */
-    public void setSelectedFile ( final File file )
-    {
-    	if ( file == null || file.exists() )
-    	{
-    		super.setSelectedFile ( file );
-    	}
-    	else
-    	{
-    		this.getFileChooserPanel ().getSelectedFilesTextField ().setText ( file.getName() );
-    		if ( file.getParent() != null && new File ( file.getParent() ).exists() ) 
-    		{
-    			this.setCurrentDirectory( file.getParent() );
-    		}
-    	}
+        setSelectedFile ( path != null ? new File ( path ) : null );
     }
 
     /**

--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooser.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooser.java
@@ -311,7 +311,7 @@ public class WebFileChooser extends JFileChooser
     	}
     	else
     	{
-    		this.getFileChooserPanel ().getSelectedFilesViewField ().setSelectedFile( file );;
+    		this.getFileChooserPanel ().getSelectedFilesViewField ().setSelectedFile( file );
     		this.getFileChooserPanel ().getSelectedFilesTextField ().setText ( file.getName () );
     		if ( file.getParent () != null && new File ( file.getParent () ).exists () ) 
     		{

--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
@@ -1121,6 +1121,16 @@ public class WebFileChooserPanel extends WebPanel
     }
 
     /**
+    * Returns the Selected Files TextField.
+    *
+    * @return Selected Files TextField
+    */
+    public WebTextField getSelectedFilesTextField () 
+    {
+    	return selectedFilesTextField;
+    }       
+    
+    /**
      * Returns file tree.
      *
      * @return file tree

--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
@@ -1128,7 +1128,17 @@ public class WebFileChooserPanel extends WebPanel
     public WebTextField getSelectedFilesTextField () 
     {
     	return selectedFilesTextField;
-    }       
+    }  
+    
+    /**
+     * Returns the Selected Files ViewField.
+     *
+     * @return Selected Files ViewField
+     */
+    public WebFileChooserField getSelectedFilesViewField () 
+    {
+    	return selectedFilesViewField;
+    }  
     
     /**
      * Returns file tree.

--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
@@ -80,9 +80,9 @@ public class WebFileChooserPanel extends WebPanel
      * todo 1. When setting "show hidden files" to false - move out from hidden directories
      * todo 2. Proper hotkeys usage within window
      * todo 3. Context menu for file selection components
-     */    
+     */
 
-	/**
+    /**
      * File name provider.
      */
     public static final FileNameProvider quotedFileNameProvider = new FileNameProvider ()
@@ -1120,15 +1120,6 @@ public class WebFileChooserPanel extends WebPanel
         }
     }
 
-    /**
-     * Returns the Selected Files TextField.
-     *
-     * @return Selected Files TextField
-     */
-    public WebTextField getSelectedFilesTextField() {
-		return selectedFilesTextField;
-	}
-    
     /**
      * Returns file tree.
      *

--- a/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
+++ b/modules/ui/src/com/alee/laf/filechooser/WebFileChooserPanel.java
@@ -80,9 +80,9 @@ public class WebFileChooserPanel extends WebPanel
      * todo 1. When setting "show hidden files" to false - move out from hidden directories
      * todo 2. Proper hotkeys usage within window
      * todo 3. Context menu for file selection components
-     */
+     */    
 
-    /**
+	/**
      * File name provider.
      */
     public static final FileNameProvider quotedFileNameProvider = new FileNameProvider ()
@@ -1120,6 +1120,15 @@ public class WebFileChooserPanel extends WebPanel
         }
     }
 
+    /**
+     * Returns the Selected Files TextField.
+     *
+     * @return Selected Files TextField
+     */
+    public WebTextField getSelectedFilesTextField() {
+		return selectedFilesTextField;
+	}
+    
     /**
      * Returns file tree.
      *


### PR DESCRIPTION
@mgarin 
This's pull request of code updates for task #419 

I've updated codes on "selectedFilesViewField" for File Open Dialog and "selectedFilesTextField" for File Save Dialog. If the defined file doesn't exist, the codes among method "setSelectedFile ()" in the class "WebFileChooser.java" will update these variables accordingly.

In order to update these variables after opening dialog, I've added getters in the class "WebFileChooserPanel.java". 

Here're few test screens:

[File Save Dialog]
- To set the selected file as "C:\\temp\\bbbb" before opening File Save Dialog:
![default](https://user-images.githubusercontent.com/7831418/29305482-9b87863e-81cb-11e7-9c7c-555c028737fe.png)
- However, there's not the file "bbbb" under "C:\\temp":
![default](https://user-images.githubusercontent.com/7831418/29305525-be999f40-81cb-11e7-90f5-85ed1c313a76.png)
- After opening File Save Dialog, the directory has been set to "C:\\temp" and file name "bbbb" has been set in the textfield:
![default](https://user-images.githubusercontent.com/7831418/29305557-e8da3dfa-81cb-11e7-8822-0c2c7a531540.png)

[File Open Dialog]
- To set the selected file as "C:\\temp\\aaaa" before opening File Open Dialog:
![default](https://user-images.githubusercontent.com/7831418/29305583-0c9c8d7e-81cc-11e7-87e6-9d4582971744.png)
- However, there's not the file "aaaa" under "C:\\temp" either:
![default](https://user-images.githubusercontent.com/7831418/29305617-39155084-81cc-11e7-92e1-006b07ae77d4.png)
- After opening File Save Dialog, the directory has been set to "C:\\temp" and file name "aaaa" has been set in the viewfield too:
![default](https://user-images.githubusercontent.com/7831418/29305638-52ee5c4e-81cc-11e7-826b-6efed553316b.png)
- Once right-clicking the file select viewfield, it'll show full path:
![default](https://user-images.githubusercontent.com/7831418/29305655-6c4b9f80-81cc-11e7-937e-760f0535ea2d.png)
- Because the file "aaaa" doesn't exist under "C:\\temp", you can find the "Open" button is always disabled in the screens of Open Dialog above. 
- The "Open" button will be enabled once selecting a file existing under the directory:
![default](https://user-images.githubusercontent.com/7831418/29305729-b9bc69c0-81cc-11e7-966b-d03a8434a4e1.png)

In addition, in order to display the pre-defined file name in viewfield of File Open Dialog, the if-else logic also need to be updated in the class "FileUtils.java".

Please kindly review the updates and provide your feedback. Thank you very much.  :-)


